### PR TITLE
bullhead: fix typo for verity on user builds

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -22,7 +22,7 @@
 PRODUCT_COPY_FILES += \
     device/lge/bullhead/init.bullhead.rc:root/init.bullhead.rc \
     device/lge/bullhead/init.bullhead.usb.rc:root/init.bullhead.usb.rc \
-    device/lge/bullhead/fstab.bullhead:root/fstab.bullhead \
+    
     device/lge/bullhead/ueventd.bullhead.rc:root/ueventd.bullhead.rc \
     device/lge/bullhead/init.bullhead.sensorhub.rc:root/init.bullhead.sensorhub.rc \
     device/lge/bullhead/init.bullhead.ramdump.rc:root/init.bullhead.ramdump.rc \
@@ -415,13 +415,14 @@ PRODUCT_COPY_FILES += \
 endif
 
 # only include verity on user builds for CM
-ifeq ($(TARGET_BUILD_VARIANT),user)
+ifeq ($(TARGET_BUILD_VARIANT),userdebug)
    PRODUCT_COPY_FILES += device/lge/bullhead/fstab-verity.bullhead:root/fstab.bullhead
-
 # setup dm-verity configs.
-PRODUCT_SYSTEM_VERITY_PARTITION := /dev/block/platform/soc.0/f9824900.sdhci/by-name/system
-#PRODUCT_VENDOR_VERITY_PARTITION := /dev/block/platform/soc.0/f9824900.sdhci/by-name/vendor
-$(call inherit-product, build/target/product/verity.mk)
+    PRODUCT_SYSTEM_VERITY_PARTITION := /dev/block/platform/soc.0/f9824900.sdhci/by-name/system
+    #PRODUCT_VENDOR_VERITY_PARTITION := /dev/block/platform/soc.0/f9824900.sdhci/by-name/vendor
+    $(call inherit-product, build/target/product/verity.mk)
+else
+    PRODUCT_COPY_FILES += device/lge/bullhead/fstab.bullhead:root/fstab.bullhead
 endif
 
 # setup dalvik vm configs.


### PR DESCRIPTION
I might be misunderstanding the intention of the if/then statement, but this pull request will build a system.img with a verity signature.  The non-verity fstab is moved to the else statement so that it is only defined once.

Users with an unlocked bootloader won't notice since they will get the orange warning.  I have a locked bootloader and these changes will result in the yellow warning with key signature.

If this change is correct, it can also be pushed to the Huawei angler and other devices that share this code.
